### PR TITLE
fix namespace problem in setUser

### DIFF
--- a/src/Message/MessageBuilder.php
+++ b/src/Message/MessageBuilder.php
@@ -3,6 +3,7 @@ namespace Slack\Message;
 
 use Slack\ApiClient;
 use Slack\ChannelInterface;
+use Slack\User;
 
 /**
  * A builder object for creating new message objects.


### PR DESCRIPTION
Catchable fatal error: Argument 1 passed to Slack\Message\MessageBuilder::setUser() must be an instance of Slack\Message\User, instance of Slack\User given