### PR TITLE
Getting DM channel by user ID

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -269,7 +269,7 @@ class ApiClient
         return $this->apiCall('im.open', [
             'user' => $id,
         ])->then(function (Payload $response) {
-            return $this->getDMById($response['channel']);
+            return $this->getDMById($response['channel']['id']);
         });
     }
 


### PR DESCRIPTION
The ID of the DMChannel is contained within $response['channel']['id'] not $response['channel'] I think?