### PR TITLE
Adding channel after joining fix

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -382,6 +382,11 @@ class RealTimeClient extends ApiClient
                     $this->team->data['domain'] = $payload['domain'];
                     break;
 
+                case 'channel_joined':
+                    $channel = new Channel($this, $payload['channel']);
+                    $this->channels[$channel->getId()] = $channel;
+                    break;
+
                 case 'channel_created':
                     $this->getChannelById($payload['channel']['id'])->then(function (Channel $channel) {
                         $this->channels[$channel->getId()] = $channel;


### PR DESCRIPTION
After joining a new channel after starting a socket connection, channels are not added to the list. That results not being able to respond messages to the new channel.