### PR TITLE
Fixed Illegal string offset due to (un)archiving channels

### DIFF
--- a/src/RealTimeClient.php
+++ b/src/RealTimeClient.php
@@ -398,11 +398,11 @@ class RealTimeClient extends ApiClient
                     break;
 
                 case 'channel_archive':
-                    $this->channels[$payload['channel']['id']]->data['is_archived'] = true;
+                    $this->channels[$payload['channel']]->data['is_archived'] = true;
                     break;
 
                 case 'channel_unarchive':
-                    $this->channels[$payload['channel']['id']]->data['is_archived'] = false;
+                    $this->channels[$payload['channel']]->data['is_archived'] = false;
                     break;
 
                 case 'group_joined':


### PR DESCRIPTION
The payload that is sent over from slack when you (un)archive a
channel collapses the "channel" sub-array to just be a string
containing the ID of the channel. That resulted in an
Illegal string offset error being thrown if the bot was in a channel
that was archived or unarchived.